### PR TITLE
Make Settings UI look like the iOS system default

### DIFF
--- a/SimRa/Base.lproj/Main.storyboard
+++ b/SimRa/Base.lproj/Main.storyboard
@@ -69,55 +69,41 @@
                         <sections>
                             <tableViewSection headerTitle="Setup" id="1uD-bL-KPo">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="8bY-Dy-320">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="vCg-lZ-qrN" style="IBUITableViewCellStyleDefault" id="8bY-Dy-320">
                                         <rect key="frame" x="0.0" y="24.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8bY-Dy-320" id="Qtp-5g-v9i">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8bY-Dy-320" id="Qtp-5g-v9i">
                                             <rect key="frame" x="0.0" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vCg-lZ-qrN">
-                                                    <rect key="frame" x="20" y="11.5" width="253" height="21"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="21" id="MMd-CX-6GT"/>
-                                                    </constraints>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="vCg-lZ-qrN">
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="vCg-lZ-qrN" secondAttribute="trailing" constant="20" symbolic="YES" id="LBQ-Dw-bNT"/>
-                                                <constraint firstItem="vCg-lZ-qrN" firstAttribute="leading" secondItem="Qtp-5g-v9i" secondAttribute="leading" constant="20" symbolic="YES" id="QYJ-sS-veM"/>
-                                                <constraint firstItem="vCg-lZ-qrN" firstAttribute="centerY" secondItem="Qtp-5g-v9i" secondAttribute="centerY" id="VcR-dV-Z3c"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="c8U-8m-Y77" kind="show" id="EUT-E4-1tq"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="sDA-LC-U9t">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="TX3-yP-atN" style="IBUITableViewCellStyleDefault" id="sDA-LC-U9t">
                                         <rect key="frame" x="0.0" y="68.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="sDA-LC-U9t" id="73d-ic-Igy">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="sDA-LC-U9t" id="73d-ic-Igy">
                                             <rect key="frame" x="0.0" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TX3-yP-atN">
-                                                    <rect key="frame" x="20" y="11.5" width="253" height="21"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="21" id="Bp7-gL-vwp"/>
-                                                    </constraints>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TX3-yP-atN">
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="TX3-yP-atN" secondAttribute="trailing" constant="20" symbolic="YES" id="22b-1s-ncM"/>
-                                                <constraint firstItem="TX3-yP-atN" firstAttribute="leading" secondItem="73d-ic-Igy" secondAttribute="leading" constant="20" symbolic="YES" id="eMV-wJ-v6c"/>
-                                                <constraint firstItem="TX3-yP-atN" firstAttribute="centerY" secondItem="73d-ic-Igy" secondAttribute="centerY" id="gP4-5r-PYO"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="NGZ-Ib-TCI" kind="show" id="LGd-bn-r2A"/>
@@ -252,28 +238,21 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="cWX-0Q-Z5a">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="rpD-ll-SMT" style="IBUITableViewCellStyleDefault" id="cWX-0Q-Z5a">
                                         <rect key="frame" x="0.0" y="381.50000034679067" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cWX-0Q-Z5a" id="Uz7-ks-bXw">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cWX-0Q-Z5a" id="Uz7-ks-bXw">
                                             <rect key="frame" x="0.0" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Credits" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rpD-ll-SMT">
-                                                    <rect key="frame" x="20" y="11.5" width="253" height="21"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="21" id="gni-8h-gfJ"/>
-                                                    </constraints>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Credits" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="rpD-ll-SMT">
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="rpD-ll-SMT" firstAttribute="centerY" secondItem="Uz7-ks-bXw" secondAttribute="centerY" id="0UF-Ur-grg"/>
-                                                <constraint firstAttribute="trailing" secondItem="rpD-ll-SMT" secondAttribute="trailing" constant="20" symbolic="YES" id="BbN-Co-KZ5"/>
-                                                <constraint firstItem="rpD-ll-SMT" firstAttribute="leading" secondItem="Uz7-ks-bXw" secondAttribute="leading" constant="20" symbolic="YES" id="vdJ-PM-w9Z"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="nN8-Nf-2E6" kind="show" id="FEG-rH-HeW"/>

--- a/SimRa/Base.lproj/Main.storyboard
+++ b/SimRa/Base.lproj/Main.storyboard
@@ -279,38 +279,28 @@
                                             <segue destination="nN8-Nf-2E6" kind="show" trigger="accessoryAction" id="FEG-rH-HeW"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="zS8-SF-nTN">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="ysy-Na-eJd" detailTextLabel="QbR-cf-yoT" style="IBUITableViewCellStyleValue1" id="zS8-SF-nTN">
                                         <rect key="frame" x="0.0" y="425.50000034679067" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zS8-SF-nTN" id="pya-Ma-Q37">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ysy-Na-eJd">
-                                                    <rect key="frame" x="20" y="11.5" width="57" height="21"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="21" id="kR7-A2-PsP"/>
-                                                    </constraints>
+                                                <label opaque="NO" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ysy-Na-eJd">
+                                                    <rect key="frame" x="16" y="12" width="57" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <textField opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="4sb-MR-RAq">
-                                                    <rect key="frame" x="85" y="7" width="215" height="30"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="30" id="NR3-Fy-u8P"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
+                                                <label opaque="NO" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" enabled="NO" adjustsFontSizeToFit="NO" id="QbR-cf-yoT">
+                                                    <rect key="frame" x="260" y="12" width="44" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="4sb-MR-RAq" secondAttribute="trailing" constant="20" symbolic="YES" id="1yv-zL-XN0"/>
-                                                <constraint firstItem="4sb-MR-RAq" firstAttribute="centerY" secondItem="pya-Ma-Q37" secondAttribute="centerY" id="7J2-Ou-Sqx"/>
-                                                <constraint firstItem="4sb-MR-RAq" firstAttribute="leading" secondItem="ysy-Na-eJd" secondAttribute="trailing" constant="8" symbolic="YES" id="DME-Uv-Tkn"/>
-                                                <constraint firstItem="ysy-Na-eJd" firstAttribute="centerY" secondItem="pya-Ma-Q37" secondAttribute="centerY" id="Pf9-9S-Qz7"/>
-                                                <constraint firstItem="ysy-Na-eJd" firstAttribute="leading" secondItem="pya-Ma-Q37" secondAttribute="leading" constant="20" symbolic="YES" id="bgp-xf-8oI"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
@@ -324,7 +314,7 @@
                     <navigationItem key="navigationItem" title="Settings" id="03L-ez-qcN"/>
                     <nil key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="version" destination="4sb-MR-RAq" id="oq8-hk-RI5"/>
+                        <outlet property="version" destination="QbR-cf-yoT" id="tnR-He-B4J"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="d3B-Kr-Puk" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/SimRa/Base.lproj/Main.storyboard
+++ b/SimRa/Base.lproj/Main.storyboard
@@ -69,15 +69,15 @@
                         <sections>
                             <tableViewSection headerTitle="Setup" id="1uD-bL-KPo">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" id="8bY-Dy-320">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="8bY-Dy-320">
                                         <rect key="frame" x="0.0" y="24.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8bY-Dy-320" id="Qtp-5g-v9i">
-                                            <rect key="frame" x="0.0" y="0.0" width="266" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vCg-lZ-qrN">
-                                                    <rect key="frame" x="20" y="11.5" width="226" height="21"/>
+                                                    <rect key="frame" x="20" y="11.5" width="253" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="21" id="MMd-CX-6GT"/>
                                                     </constraints>
@@ -96,15 +96,15 @@
                                             <segue destination="c8U-8m-Y77" kind="show" id="EUT-E4-1tq"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" id="sDA-LC-U9t">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="sDA-LC-U9t">
                                         <rect key="frame" x="0.0" y="68.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="sDA-LC-U9t" id="73d-ic-Igy">
-                                            <rect key="frame" x="0.0" y="0.0" width="266" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TX3-yP-atN">
-                                                    <rect key="frame" x="20" y="11.5" width="226" height="21"/>
+                                                    <rect key="frame" x="20" y="11.5" width="253" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="21" id="Bp7-gL-vwp"/>
                                                     </constraints>
@@ -252,15 +252,15 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" id="cWX-0Q-Z5a">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="cWX-0Q-Z5a">
                                         <rect key="frame" x="0.0" y="381.50000034679067" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cWX-0Q-Z5a" id="Uz7-ks-bXw">
-                                            <rect key="frame" x="0.0" y="0.0" width="266" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Credits" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rpD-ll-SMT">
-                                                    <rect key="frame" x="20" y="11.5" width="226" height="21"/>
+                                                    <rect key="frame" x="20" y="11.5" width="253" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="21" id="gni-8h-gfJ"/>
                                                     </constraints>

--- a/SimRa/Base.lproj/Main.storyboard
+++ b/SimRa/Base.lproj/Main.storyboard
@@ -62,7 +62,7 @@
         <scene sceneID="pZY-AP-PkF">
             <objects>
                 <tableViewController hidesBottomBarWhenPushed="YES" id="Zrj-ys-gys" customClass="SettingsTVC" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="320-4m-rIz">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="320-4m-rIz">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -93,7 +93,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="c8U-8m-Y77" kind="show" trigger="accessoryAction" id="EUT-E4-1tq"/>
+                                            <segue destination="c8U-8m-Y77" kind="show" id="EUT-E4-1tq"/>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" id="sDA-LC-U9t">
@@ -120,7 +120,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="NGZ-Ib-TCI" kind="show" trigger="accessoryAction" id="LGd-bn-r2A"/>
+                                            <segue destination="NGZ-Ib-TCI" kind="show" id="LGd-bn-r2A"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -276,7 +276,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="nN8-Nf-2E6" kind="show" trigger="accessoryAction" id="FEG-rH-HeW"/>
+                                            <segue destination="nN8-Nf-2E6" kind="show" id="FEG-rH-HeW"/>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="ysy-Na-eJd" detailTextLabel="QbR-cf-yoT" style="IBUITableViewCellStyleValue1" id="zS8-SF-nTN">

--- a/SimRa/Base.lproj/Main.storyboard
+++ b/SimRa/Base.lproj/Main.storyboard
@@ -120,22 +120,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hy8-yG-bWd">
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="Hy8-yG-bWd">
                                                     <rect key="frame" x="20" y="7" width="280" height="30"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="30" id="oHt-t2-wu1"/>
-                                                    </constraints>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <state key="normal" title="About"/>
                                                     <connections>
                                                         <action selector="aboutPressed:" destination="Zrj-ys-gys" eventType="touchUpInside" id="0zt-sb-Sab"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="Hy8-yG-bWd" firstAttribute="leading" secondItem="jxU-bE-qns" secondAttribute="leading" constant="20" symbolic="YES" id="G88-Br-Xdd"/>
-                                                <constraint firstItem="Hy8-yG-bWd" firstAttribute="centerY" secondItem="jxU-bE-qns" secondAttribute="centerY" id="KXm-RG-2ss"/>
-                                                <constraint firstAttribute="trailing" secondItem="Hy8-yG-bWd" secondAttribute="trailing" constant="20" symbolic="YES" id="gPB-fn-Q5p"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Tug-GQ-2NO">
@@ -145,22 +138,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XcY-SK-4YC">
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="XcY-SK-4YC">
                                                     <rect key="frame" x="20" y="7" width="280" height="30"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="30" id="mdA-Jy-lCA"/>
-                                                    </constraints>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <state key="normal" title="Privacy"/>
                                                     <connections>
                                                         <action selector="privacyPressed:" destination="Zrj-ys-gys" eventType="touchUpInside" id="F4y-Xo-aFy"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="XcY-SK-4YC" secondAttribute="trailing" constant="20" symbolic="YES" id="08U-Je-NVg"/>
-                                                <constraint firstItem="XcY-SK-4YC" firstAttribute="leading" secondItem="ZMj-4K-QfI" secondAttribute="leading" constant="20" symbolic="YES" id="HMU-0A-cgl"/>
-                                                <constraint firstItem="XcY-SK-4YC" firstAttribute="centerY" secondItem="ZMj-4K-QfI" secondAttribute="centerY" id="u23-92-5rJ"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Ajx-DX-0M1">
@@ -170,22 +156,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QeF-cV-htR">
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="QeF-cV-htR">
                                                     <rect key="frame" x="20" y="7" width="280" height="30"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="30" id="1j1-1Q-wfj"/>
-                                                    </constraints>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <state key="normal" title="How To"/>
                                                     <connections>
                                                         <action selector="howtoPressed:" destination="Zrj-ys-gys" eventType="touchUpInside" id="rdy-ZR-CNc"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="QeF-cV-htR" firstAttribute="leading" secondItem="EYs-HS-qlx" secondAttribute="leading" constant="20" symbolic="YES" id="I4j-es-zYj"/>
-                                                <constraint firstItem="QeF-cV-htR" firstAttribute="centerY" secondItem="EYs-HS-qlx" secondAttribute="centerY" id="LFD-Ps-yBc"/>
-                                                <constraint firstAttribute="trailing" secondItem="QeF-cV-htR" secondAttribute="trailing" constant="20" symbolic="YES" id="hrB-6V-uMf"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Khc-gb-LB0">
@@ -195,22 +174,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vwj-ml-5PX">
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="vwj-ml-5PX">
                                                     <rect key="frame" x="20" y="7" width="280" height="30"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="30" id="wGZ-HI-FpD"/>
-                                                    </constraints>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <state key="normal" title="Feedback"/>
                                                     <connections>
                                                         <action selector="feedbackPressed:" destination="Zrj-ys-gys" eventType="touchUpInside" id="qbg-fs-gdp"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="vwj-ml-5PX" firstAttribute="centerY" secondItem="bjt-9o-maV" secondAttribute="centerY" id="9UU-It-mYe"/>
-                                                <constraint firstAttribute="trailing" secondItem="vwj-ml-5PX" secondAttribute="trailing" constant="20" symbolic="YES" id="Uep-8N-WCW"/>
-                                                <constraint firstItem="vwj-ml-5PX" firstAttribute="leading" secondItem="bjt-9o-maV" secondAttribute="leading" constant="20" symbolic="YES" id="fUS-7M-AZ5"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="rxz-bU-byc">
@@ -220,22 +192,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DY1-7h-Asu">
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="DY1-7h-Asu">
                                                     <rect key="frame" x="20" y="7" width="280" height="30"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="30" id="eWo-10-s4r"/>
-                                                    </constraints>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <state key="normal" title="Imprint"/>
                                                     <connections>
                                                         <action selector="imprintPressed:" destination="Zrj-ys-gys" eventType="touchUpInside" id="hNO-Fp-J10"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="DY1-7h-Asu" secondAttribute="trailing" constant="20" symbolic="YES" id="bSg-BN-9JL"/>
-                                                <constraint firstItem="DY1-7h-Asu" firstAttribute="centerY" secondItem="8as-5V-Wva" secondAttribute="centerY" id="pzJ-1l-9Pf"/>
-                                                <constraint firstItem="DY1-7h-Asu" firstAttribute="leading" secondItem="8as-5V-Wva" secondAttribute="leading" constant="20" symbolic="YES" id="xth-Ly-B40"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="rpD-ll-SMT" style="IBUITableViewCellStyleDefault" id="cWX-0Q-Z5a">
@@ -2275,7 +2240,7 @@ from www.flaticon.com</string>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="2hm-aX-QV5"/>
+        <segue reference="EUT-E4-1tq"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="Simra" width="300" height="186"/>

--- a/SimRa/SettingsTVC.m
+++ b/SimRa/SettingsTVC.m
@@ -34,7 +34,7 @@
 @property (weak, nonatomic) IBOutlet UITextField *totalIncidents;
 @property (weak, nonatomic) IBOutlet UITextField *totalIdle;
 @property (weak, nonatomic) IBOutlet UIView *totalSlots;
-@property (weak, nonatomic) IBOutlet UITextField *version;
+@property (weak, nonatomic) IBOutlet UILabel *version;
 @property (weak, nonatomic) IBOutlet UITextField *scaryEvents;
 @property (weak, nonatomic) IBOutlet UITextField *totalCO2;
 @property (weak, nonatomic) IBOutlet UITextField *averageSpeed;


### PR DESCRIPTION
By using system standard controls it's possible to achieve a style that's more compliant with the rest of iOS and thus more familiar to the users. At the same time we reduce code size.
![Simulator Screen Shot - iPhone SE - 2021-05-02 at 11 08 29](https://user-images.githubusercontent.com/14293962/116815367-764d0780-ab5d-11eb-8cf1-5d972d72c3ab.png)

For comparision the old look:
![Simulator Screen Shot - iPhone SE - 2021-05-02 at 11 10 20](https://user-images.githubusercontent.com/14293962/116815403-b7451c00-ab5d-11eb-8d76-616de901374a.png)

 