### PR TITLE
[CLEANUP] Use framework functionality for localized resources

### DIFF
--- a/SimRa/AppDelegate.m
+++ b/SimRa/AppDelegate.m
@@ -25,16 +25,8 @@
     self.trips = [[Trips alloc] init];
     [self.trips save];
 
-    NSURL *bundleURL = [NSBundle mainBundle].bundleURL;
-    NSURL *baseURL = [bundleURL URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.lproj",
-                                                      [NSLocale currentLocale].languageCode]];
-    NSURL *constantsURL = [baseURL URLByAppendingPathComponent:@"constants.plist"];
+    NSURL *constantsURL = [[NSBundle mainBundle] URLForResource:@"constants" withExtension:@"plist"];
     self.constants = [NSDictionary dictionaryWithContentsOfURL:constantsURL];
-    if (!self.constants) {
-        baseURL = [bundleURL URLByAppendingPathComponent:@"Base.lproj"];
-        constantsURL = [baseURL URLByAppendingPathComponent:@"constants.plist"];
-        self.constants = [NSDictionary dictionaryWithContentsOfURL:constantsURL];
-    }
 
     return YES;
 }

--- a/SimRa/Regions.m
+++ b/SimRa/Regions.m
@@ -170,15 +170,11 @@
 
     if (!self.regions) {
         self.regions = [[NSMutableArray alloc] init];
-        NSURL *bundleURL = [NSBundle mainBundle].bundleURL;
-
-        NSURL *baseURL = [bundleURL URLByAppendingPathComponent:@"de.lproj"];
-        NSURL *constantsURL = [baseURL URLByAppendingPathComponent:@"constants.plist"];
+        NSURL *constantsURL = [[NSBundle mainBundle] URLForResource:@"constants" withExtension:@"plist" subdirectory:nil localization:@"de"];
         NSDictionary *germanConstants = [NSDictionary dictionaryWithContentsOfURL:constantsURL];
         NSArray *germanRegions = germanConstants[@"regions"];
 
-        baseURL = [bundleURL URLByAppendingPathComponent:@"Base.lproj"];
-        constantsURL = [baseURL URLByAppendingPathComponent:@"constants.plist"];
+        constantsURL = [[NSBundle mainBundle] URLForResource:@"constants" withExtension:@"plist" subdirectory:nil localization:@"Base"];
         NSDictionary *englishConstants = [NSDictionary dictionaryWithContentsOfURL:constantsURL];
         NSArray *englishRegions = englishConstants[@"regions"];
 


### PR DESCRIPTION
Using the framework functionality produces simpler code and does exactly what we want.
Even a bit more: It produces better results if only a secondary fallback language from the system settings can be matched.