### PR TITLE
[FIX] When initializing the Trip properties, use the correct keys when accessing user defaults.

### DIFF
--- a/SimRa/Trip.m
+++ b/SimRa/Trip.m
@@ -768,7 +768,7 @@
 - (void)startRecording {
     AppDelegate *ad = (AppDelegate *)[UIApplication sharedApplication].delegate;
     self.deferredSecs = [ad.defaults integerForKey:@"deferredSecs"];
-    self.deferredMeters = [ad.defaults integerForKey:@"deferredSecs"];
+    self.deferredMeters = [ad.defaults integerForKey:@"deferredMeters"];
     self.bikeTypeId = [ad.defaults integerForKey:@"bikeTypeId"];
     self.positionId = [ad.defaults integerForKey:@"positionId"];
     self.childseat = [ad.defaults integerForKey:@"childSeat"];

--- a/SimRa/Trip.m
+++ b/SimRa/Trip.m
@@ -771,7 +771,7 @@
     self.deferredMeters = [ad.defaults integerForKey:@"deferredSecs"];
     self.bikeTypeId = [ad.defaults integerForKey:@"bikeTypeId"];
     self.positionId = [ad.defaults integerForKey:@"positionId"];
-    self.childseat = [ad.defaults integerForKey:@"childseat"];
+    self.childseat = [ad.defaults integerForKey:@"childSeat"];
     self.trailer = [ad.defaults boolForKey:@"trailer"];
 
     if (ad.mm.isGyroAvailable) {


### PR DESCRIPTION
Currently the childseat property is always initialized to false, because the wrong user defaults key is used.

Note: The user defaults key for child set is "childSeat" (camel case) while the storage key is "childseat" (lowercase).
Both are persisted, so we can't unify them.